### PR TITLE
Fix install command in readme

### DIFF
--- a/README-fi.md
+++ b/README-fi.md
@@ -18,7 +18,7 @@ Voikon kotisivut löytyvät osoitteesta: http://voikko.puimula.org/
 Avaa Terminal (pääte) ja kirjoita alla olevat komennot:
 
 1. Asenna (Homebrew)[https://brew.sh/]: `$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"”`
-1. Asenna voikkospellservice: `$ brew install voikkospellservice`
+1. Asenna voikkospellservice: `$ brew install --cask voikkospellservice`
 1. Oikoluvun pitäisi olla nyt käytettävissä.
 
 ## Asennus paketista

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Voikko projects homepage is at: http://voikko.puimula.org/
 Open Terminal and first install Homebrew and Cask.
 
 1. Install (Homebrew)[https://brew.sh/]: `$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"”`
-1. Install voikkospellservice: `$ brew cask install voikkospellservice`
+1. Install voikkospellservice: `$ brew install --cask voikkospellservice`
 1. Voikko Spellchecking should be now available.
 
 ## Installation from dmg package


### PR DESCRIPTION
The command was not valid anymore:

```
$ brew cask install voikkospellservice
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```

Updated to:

```
$ brew install --cask voikkospellservice
```